### PR TITLE
typecast inst.t_offset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FMIBase"
 uuid = "900ee838-d029-460e-b485-d98a826ceef2"
 authors = ["TT <tobias.thummerer@informatik.uni-augsburg.de>", "LM <lars.mikelsons@informatik.uni-augsburg.de>"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/FMI2/struct.jl
+++ b/src/FMI2/struct.jl
@@ -138,7 +138,7 @@ mutable struct FMU2Component{F} <: FMUInstance
         inst.cRef = UInt64(pointer_from_objref(inst))
         inst.state = fmi2ComponentStateInstantiated
         inst.t = NO_fmi2Real
-        inst.t_offset = 0.0
+        inst.t_offset = fmi2Real(0.0)
         inst.problem = nothing
         inst.type = nothing
         inst.threadid = Threads.threadid()

--- a/src/FMI3/struct.jl
+++ b/src/FMI3/struct.jl
@@ -149,7 +149,7 @@ mutable struct FMU3Instance{F} <: FMUInstance
         inst.cRef = UInt64(pointer_from_objref(inst))
         inst.state = fmi3InstanceStateInstantiated
         inst.t = NO_fmi3Float64
-        inst.t_offset = 0.0
+        inst.t_offset = fmi3Float64(0.0)
         inst.problem = nothing
         inst.type = nothing
         inst.threadid = Threads.threadid()

--- a/src/common.jl
+++ b/src/common.jl
@@ -53,7 +53,7 @@ function getContinuousStates(c::FMU2Component)
         fmi2GetContinuousStates!(c, x, nx) 
         return x
     else
-        return [0.0] 
+        return zeros(fmi2Real, 1) 
     end
 end
 function getContinuousStates(c::FMU3Instance)
@@ -63,7 +63,7 @@ function getContinuousStates(c::FMU3Instance)
         fmi3GetContinuousStates!(c, x, nx) 
         return x
     else
-        return [0.0] 
+        return zeros(fmi3Float64, 1)
     end
 end
 


### PR DESCRIPTION
This is necessary for 32-Bit Support, because Julia defaults to Float64 for floating point numbers even on 32-Bit-Systems