### PR TITLE
Replace fmi2ModelVariablesForValueReference and fmi3ModelVariablesForValueReference

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FMIBase"
 uuid = "900ee838-d029-460e-b485-d98a826ceef2"
 authors = ["TT <tobias.thummerer@informatik.uni-augsburg.de>", "LM <lars.mikelsons@informatik.uni-augsburg.de>"]
-version = "1.0.7"
+version = "1.0.8"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/md.jl
+++ b/src/md.jl
@@ -704,7 +704,7 @@ function getStartValue(
     starts = []
 
     for vr in vrs
-        mvs = fmi2ModelVariablesForValueReference(md, vr)
+        mvs = modelVariablesForValueReference(md, vr)
 
         if length(mvs) == 0
             @warn "getStartValue(...): Found no model variable with value reference $(vr)."
@@ -735,7 +735,7 @@ function getStartValue(
     starts = []
 
     for vr in vrs
-        mvs = fmi3ModelVariablesForValueReference(md, vr)
+        mvs = modelVariablesForValueReference(md, vr)
 
         if length(mvs) == 0
             @warn "getStartValue(...): Found no model variable with value reference $(vr)."
@@ -766,7 +766,7 @@ function getStartValue(
     starts = []
 
     for vr in vrs
-        mvs = fmi2ModelVariablesForValueReference(c.fmu.modelDescription, vr)
+        mvs = modelVariablesForValueReference(c.fmu.modelDescription, vr)
 
         if length(mvs) == 0
             @warn "fmi2GetStartValue(...): Found no model variable with value reference $(vr)."
@@ -818,7 +818,7 @@ function getStartValue(
     starts = []
 
     for vr in vrs
-        mvs = fmi3ModelVariablesForValueReference(c.fmu.modelDescription, vr)
+        mvs = modelVariablesForValueReference(c.fmu.modelDescription, vr)
 
         if length(mvs) == 0
             @warn "fmi3GetStartValue(...): Found no model variable with value reference $(vr)."


### PR DESCRIPTION
The functions `fmi2ModelVariablesForValueReference` and `fmi3ModelVariablesForValueReference` are not defined anywhere. I believe they were replaced with `modelVariablesForValueReference`, so i replaced the calls.