### PR TITLE
Dependency Information Support in Base

### DIFF
--- a/src/FMI2/struct.jl
+++ b/src/FMI2/struct.jl
@@ -398,6 +398,10 @@ mutable struct FMU2 <: FMU
     # execution configuration
     executionConfig::FMUExecutionConfiguration
 
+    # sparsity
+    dependencyMatrix::Union{AbstractDependencyMatrix,Nothing}
+    jac_prototype::Union{AbstractMatrix,Nothing}
+
     # events
     hasStateEvents::Union{Bool,Nothing}
     hasTimeEvents::Union{Bool,Nothing}
@@ -442,6 +446,9 @@ mutable struct FMU2 <: FMU
         inst.isDummyDiscrete = false
 
         inst.executionConfig = FMU_EXECUTION_CONFIGURATION_NO_RESET
+        inst.dependencyMatrix = nothing
+        inst.jac_prototype = nothing
+
         inst.threadInstances = Dict{Integer,Union{FMU2Component,Nothing}}()
         inst.cFunctionPtrs = Dict{String,Ptr{Nothing}}()
 

--- a/src/FMI3/struct.jl
+++ b/src/FMI3/struct.jl
@@ -461,6 +461,10 @@ mutable struct FMU3 <: FMU
     # execution configuration
     executionConfig::FMUExecutionConfiguration
 
+    # sparsity
+    dependencyMatrix::Union{AbstractDependencyMatrix,Nothing}
+    jac_prototype::Union{AbstractMatrix,Nothing}
+
     # events
     hasStateEvents::Union{Bool,Nothing}
     hasTimeEvents::Union{Bool,Nothing}
@@ -507,6 +511,9 @@ mutable struct FMU3 <: FMU
         inst.isDummyDiscrete = false
 
         inst.executionConfig = FMU_EXECUTION_CONFIGURATION_NO_RESET
+        inst.dependencyMatrix = nothing
+        inst.jac_prototype = nothing
+
         inst.threadInstances = Dict{Integer,Union{FMU2Component,Nothing}}()
         inst.cFunctionPtrs = Dict{String,Ptr{Nothing}}()
 

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -66,6 +66,10 @@ function setupSolver!(fmu::FMU, tspan, kwargs)
     return tspan
 end
 
+# Stub — overloaded by FMIImport's SparseArraysExt when SparseArrays is loaded
+function loadDependencyMatrix!(::FMU) end
+export loadDependencyMatrix!
+
 # sets up the ODEProblem for simulating a ME-FMU
 function setupODEProblem(
     c::FMUInstance,
@@ -76,7 +80,8 @@ function setupODEProblem(
 )
 
     fx = (dx, x, p, t) -> f(c, dx, x, p, t, inputFunction)
-    ff = ODEFunction{true}(fx) # , tgrad=nothing)
+    jp = c.fmu.executionConfig.use_jac_prototype ? c.fmu.jac_prototype : nothing
+    ff = ODEFunction{true}(fx; jac_prototype = jp)
     return ODEProblem{true}(ff, x0, tspan, p)
 end
 

--- a/src/struct.jl
+++ b/src/struct.jl
@@ -22,6 +22,15 @@ abstract type FMUInstance end
 export FMUInstance
 
 """
+    AbstractDependencyMatrix
+
+Abstract type for dependency matrices derived from FMU model descriptions.
+Concrete implementation lives in FMIImport's SparseArraysExt.
+"""
+abstract type AbstractDependencyMatrix end
+export AbstractDependencyMatrix
+
+"""
 A mutable struct representing the excution configuration of a FMU.
 For FMUs that have issues with calls like `fmi2Reset` or `fmi2FreeInstance`, this is pretty useful.
 
@@ -99,7 +108,10 @@ mutable struct FMUExecutionConfiguration
     finitediff_absstep::Float64
 
 
-    # deprecated 
+    load_dep_matrix::Bool                   # build DependencyMatrix during loadFMU (requires SparseArrays)
+    use_jac_prototype::Bool                 # pass jac_prototype to ODEFunction when available
+
+    # deprecated
     concat_eval::Bool                       # wheter FMU/Component evaluation should return a tuple (y, dx, ec) or a conacatenation [y..., dx..., ec...]
     isolatedStateDependency::Any
 
@@ -150,7 +162,10 @@ mutable struct FMUExecutionConfiguration
         inst.finitediff_relstep = -1.0           # < 0.0 use FiniteDiff default
         inst.finitediff_absstep = -1.0           # < 0.0 use FiniteDiff default
 
-        # deprecated 
+        inst.load_dep_matrix = true
+        inst.use_jac_prototype = true
+
+        # deprecated
         inst.concat_eval = true
         inst.isolatedStateDependency = false
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,5 +14,6 @@ using CSV, DataFrames, ForwardDiff, JLD2, MAT, Plots, ReverseDiff
     include("load_save.jl")
     include("valueRefs_md.jl")
     include("struct_solution.jl")
+    include("sparsity.jl")
     include("real_fmu.jl")
 end

--- a/test/sparsity.jl
+++ b/test/sparsity.jl
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2024 Tobias Thummerer, Lars Mikelsons
+# Licensed under the MIT license. See LICENSE file in the project root for details.
+#
+
+@testset "AbstractDependencyMatrix" begin
+    @test isabstracttype(AbstractDependencyMatrix)
+end
+
+@testset "FMUExecutionConfiguration sparsity defaults" begin
+    cfg = FMUExecutionConfiguration()
+    @test cfg.load_dep_matrix == true
+    @test cfg.use_jac_prototype == true
+end
+
+@testset "FMU2 sparsity fields" begin
+    fmu = FMU2()
+    @test isnothing(fmu.dependencyMatrix)
+    @test isnothing(fmu.jac_prototype)
+end
+
+@testset "FMU3 sparsity fields" begin
+    fmu = FMU3()
+    @test isnothing(fmu.dependencyMatrix)
+    @test isnothing(fmu.jac_prototype)
+end


### PR DESCRIPTION
- add Abstract Type for Dependency Matrix
- add sparsity related fields in FMU-struct
- add sparsity related fields to ExecutionConfig
- add stub for loading Dependency Matrix -> overwritten in FMIImport when SparseArrays is present
- add passing of `jac_prototype` to `setupODEProblem`